### PR TITLE
Method name for setting the clear color has changed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ png = ["miniz_oxide"]
 
 [dev-dependencies]
 #pixels = "0.8"
-pixels = { git = "https://github.com/parasyte/pixels", branch="feature/clear-color" }
+pixels = { git = "https://github.com/parasyte/pixels", rev = "4c6682e65bb417cdaa6e9964cbace5369149452d" }
 winit = "0.25"

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), Error> {
     let surface_texture = SurfaceTexture::new(window_size.width, window_size.height, &window);
     Pixels::new(width, height, surface_texture)?
   };
-  pixels.clear_color(Color::WHITE);
+  pixels.set_clear_color(Color::WHITE);
 
   event_loop.run(move |event, _, control_flow| match event {
     Event::WindowEvent { event: WindowEvent::CloseRequested, .. } => {


### PR DESCRIPTION
Changes the `pixels` dependency to a specific revision (aka commit hash) to avoid breaking changes like this one. I renamed the setter method based on your comment. This revision is on the main branch, so it should not be much trouble to keep it up to date as much as you like.