### PR TITLE
Bump miniz_oxide and pack1 dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ bytemuck = { version = "1.13.1", features = ["derive", "min_const_generics"] }
 
 png_filters = { version = "0.1", optional = true }
 bitfrob = { version = "1.3.0", features= ["track_caller"], optional = true }
-miniz_oxide = { version = "0.7.1", default-features = false, optional = true }
-pack1 = { version = "0.1.1", features = ["bytemuck"], optional = true }
+miniz_oxide = { version = "0.8.8", default-features = false, optional = true }
+pack1 = { version = "1.0", features = ["bytemuck"], optional = true }
 
 #wide = { version = "0.7.8", default-features = false, optional = true }
 


### PR DESCRIPTION
This bumps `miniz_oxide` from 0.7 to 0.8; [this release just bumped its MSRV to 1.56 and switched from adler to adler2.](https://github.com/Frommi/miniz_oxide/blob/master/CHANGELOG.md#080---2024-08-08)

This bumps `pack1` from 0.1.1 to 1.0 (no changes).

